### PR TITLE
There is a bug in this cleaner subroutine when a path contains three rel...

### DIFF
--- a/voiceglue/voiceglue
+++ b/voiceglue/voiceglue
@@ -456,6 +456,7 @@ sub clean_url_path
 	elsif (($components[$i] eq "..") && ($i > 0))
 	{
 	    splice (@components, $i-1, 2);
+	    $i--;
 	}
 	else
 	{


### PR DESCRIPTION
...ative previous directory references. Such as,

/aaa/bbb/ccc/../../../file.wav
currently 
/aaa/bbb/ccc/../../../file.wav
/aaa/bbb/162.wav
Adding the Subtraction $i--;
allows the iterator $i to be indexed to the correct part of the array to allow the splice to progress correctly.
Like this.
/aaa/bbb/ccc/../../../file.wav
/file.wav
